### PR TITLE
Remove my API key from PolygonWebsocketTestDriver Oops!

### DIFF
--- a/src/main/java/io/github/mainstringargs/polygon/websocket/PolygonWebsocketTestDriver.java
+++ b/src/main/java/io/github/mainstringargs/polygon/websocket/PolygonWebsocketTestDriver.java
@@ -22,7 +22,7 @@ public class PolygonWebsocketTestDriver {
     public static void main(String[] args) {
         //  Configurator.setRootLevel(Level.ALL);
 
-        PolygonWebsocketClient client = new PolygonWebsocketClient("AKKHS7AT2BYZNMLF30ZA",
+        PolygonWebsocketClient client = new PolygonWebsocketClient(PolygonProperties.KEY_ID_VALUE,
                 PolygonProperties.POLYGON_WEB_SOCKET_SERVER_URL_VALUE);
 
         Map<String, Set<ChannelType>> subscribedTypes = new HashMap<>();


### PR DESCRIPTION
Accidentally left my API key in `PolygonWebsocketTestDriver` class when I was testing it. I've regenerated my keys (thankfully Alpaca lets you do this) and that one is no longer valid. Oops!