### PR TITLE
Fix Polygon Websockets

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,8 +57,7 @@ dependencies {
     compile 'org.apache.logging.log4j:log4j-api:2.11.1'
     compile 'org.apache.logging.log4j:log4j-core:2.11.1'
 
-    compile "javax.websocket:javax.websocket-api:1.1"
-    compile "org.glassfish.tyrus.bundles:tyrus-standalone-client-jdk:1.12"
+    compile "org.eclipse.jetty.websocket:javax-websocket-client-impl:9.4.28.v20200408"
 
     // Use JUnit test framework
     testCompile 'junit:junit:4.12'

--- a/src/main/java/io/github/mainstringargs/abstracts/websocket/client/AbstractWebsocketClientEndpoint.java
+++ b/src/main/java/io/github/mainstringargs/abstracts/websocket/client/AbstractWebsocketClientEndpoint.java
@@ -14,12 +14,12 @@ import java.net.URI;
 import java.util.concurrent.ExecutorService;
 
 /**
- * The type Abstract websocket client endpoint. You must annotate subclasses with {@link javax.websocket.ClientEndpoint}
- * because websocket annotations don't work with inheritance.
- *
- * @param <T> the message type parameter
+ * The type Abstract websocket client endpoint. You must annotate a subclass with {@link javax.websocket.ClientEndpoint}
+ * and the appropriate websocket subprotocols because websocket annotations don't work with inheritance. The subclass
+ * must also contain separate methods with the following annotations: {@link javax.websocket.OnOpen}, {@link
+ * javax.websocket.OnClose}, and {@link javax.websocket.OnMessage}.
  */
-public abstract class AbstractWebsocketClientEndpoint<T> {
+public abstract class AbstractWebsocketClientEndpoint {
 
     /** The constant LOGGER. */
     private static final Logger LOGGER = LogManager.getLogger(AbstractWebsocketClientEndpoint.class);
@@ -54,32 +54,6 @@ public abstract class AbstractWebsocketClientEndpoint<T> {
     }
 
     /**
-     * On open annotated. You must annotate this with {@link javax.websocket.OnOpen} and call {@link
-     * AbstractWebsocketClientEndpoint#onOpen(Session)} because websocket annotations don't work with inheritance.
-     *
-     * @param userSession the user session
-     */
-    public abstract void onOpenAnnotated(Session userSession);
-
-    /**
-     * On close annotated. You must annotate this with {@link javax.websocket.OnClose} and call {@link
-     * AbstractWebsocketClientEndpoint#onClose(Session, CloseReason)}} because websocket annotations don't work with
-     * inheritance.
-     *
-     * @param userSession the user session
-     * @param reason      the reason
-     */
-    public abstract void onCloseAnnotated(Session userSession, CloseReason reason);
-
-    /**
-     * On message annotated. You must annotate this with {@link javax.websocket.OnMessage} and call {@link
-     * AbstractWebsocketClientEndpoint#onMessage(String)}} because websocket annotations don't work with inheritance.
-     *
-     * @param message the message
-     */
-    public abstract void onMessageAnnotated(T message);
-
-    /**
      * Connect.
      *
      * @throws DeploymentException the deployment exception
@@ -109,7 +83,7 @@ public abstract class AbstractWebsocketClientEndpoint<T> {
      *
      * @param userSession the user session
      */
-    public void onOpen(Session userSession) {
+    protected void onOpen(Session userSession) {
         this.userSession = userSession;
 
         LOGGER.debug("onOpen " + userSession);
@@ -125,7 +99,7 @@ public abstract class AbstractWebsocketClientEndpoint<T> {
      * @param userSession the user session
      * @param reason      the reason
      */
-    public void onClose(Session userSession, CloseReason reason) {
+    protected void onClose(Session userSession, CloseReason reason) {
         this.userSession = null;
 
         LOGGER.debug("onClose " + userSession);
@@ -163,7 +137,7 @@ public abstract class AbstractWebsocketClientEndpoint<T> {
      *
      * @param message the message
      */
-    public void onMessage(String message) {
+    protected void onMessage(String message) {
         executorService.execute(() -> websocketClient.handleWebsocketMessage(message));
     }
 

--- a/src/main/java/io/github/mainstringargs/alpaca/AlpacaAPI.java
+++ b/src/main/java/io/github/mainstringargs/alpaca/AlpacaAPI.java
@@ -526,10 +526,10 @@ public class AlpacaAPI {
      * A stop (market) order is an order to buy or sell a security when its price moves past a particular point,
      * ensuring a higher probability of achieving a predetermined entry or exit price. Once the market price crosses the
      * specified stop price, the stop order becomes a market order. Alpaca converts buy stop orders into stop limit
-     * orders with a limit price that is 4% higher than a stop price &lt; $50 (or 2.5% higher than a stop price &gt;= $50).
-     * Sell stop orders are not converted into stop limit orders. This method calls {@link #requestNewOrder(String,
-     * Integer, OrderSide, OrderType, OrderTimeInForce, Double, Double, Boolean, String, OrderClass, Double, Double,
-     * Double)} with {@link OrderType#STOP}.
+     * orders with a limit price that is 4% higher than a stop price &lt; $50 (or 2.5% higher than a stop price &gt;=
+     * $50). Sell stop orders are not converted into stop limit orders. This method calls {@link
+     * #requestNewOrder(String, Integer, OrderSide, OrderType, OrderTimeInForce, Double, Double, Boolean, String,
+     * OrderClass, Double, Double, Double)} with {@link OrderType#STOP}.
      *
      * @param symbol        symbol or asset ID to identify the asset to trade
      * @param quantity      number of shares to trade

--- a/src/main/java/io/github/mainstringargs/alpaca/rest/AlpacaRequest.java
+++ b/src/main/java/io/github/mainstringargs/alpaca/rest/AlpacaRequest.java
@@ -1,7 +1,7 @@
 package io.github.mainstringargs.alpaca.rest;
 
-import io.github.mainstringargs.alpaca.properties.AlpacaProperties;
 import io.github.mainstringargs.abstracts.rest.AbstractRequest;
+import io.github.mainstringargs.alpaca.properties.AlpacaProperties;
 
 /**
  * The Class AlpacaRequest.

--- a/src/main/java/io/github/mainstringargs/alpaca/websocket/client/AlpacaWebsocketClientEndpoint.java
+++ b/src/main/java/io/github/mainstringargs/alpaca/websocket/client/AlpacaWebsocketClientEndpoint.java
@@ -15,8 +15,8 @@ import java.nio.charset.StandardCharsets;
 /**
  * The type Alpaca websocket client endpoint.
  */
-@ClientEndpoint
-public class AlpacaWebsocketClientEndpoint extends AbstractWebsocketClientEndpoint<byte[]> {
+@ClientEndpoint(subprotocols = "BINARY")
+public class AlpacaWebsocketClientEndpoint extends AbstractWebsocketClientEndpoint {
 
     /**
      * Instantiates a new Alpaca websocket client endpoint.
@@ -29,19 +29,16 @@ public class AlpacaWebsocketClientEndpoint extends AbstractWebsocketClientEndpoi
     }
 
     @OnOpen
-    @Override
     public void onOpenAnnotated(Session userSession) {
         super.onOpen(userSession);
     }
 
     @OnClose
-    @Override
     public void onCloseAnnotated(Session userSession, CloseReason reason) {
         super.onClose(userSession, reason);
     }
 
     @OnMessage
-    @Override
     public void onMessageAnnotated(byte[] message) {
         super.onMessage(new String(message, StandardCharsets.UTF_8));
     }

--- a/src/main/java/io/github/mainstringargs/polygon/rest/PolygonRequest.java
+++ b/src/main/java/io/github/mainstringargs/polygon/rest/PolygonRequest.java
@@ -1,9 +1,9 @@
 package io.github.mainstringargs.polygon.rest;
 
 import com.mashape.unirest.http.HttpResponse;
-import io.github.mainstringargs.polygon.properties.PolygonProperties;
 import io.github.mainstringargs.abstracts.rest.AbstractRequest;
 import io.github.mainstringargs.abstracts.rest.AbstractRequestBuilder;
+import io.github.mainstringargs.polygon.properties.PolygonProperties;
 
 import java.io.InputStream;
 

--- a/src/main/java/io/github/mainstringargs/polygon/websocket/client/PolygonWebsocketClientEndpoint.java
+++ b/src/main/java/io/github/mainstringargs/polygon/websocket/client/PolygonWebsocketClientEndpoint.java
@@ -14,8 +14,8 @@ import java.net.URI;
 /**
  * The type Polygon websocket client endpoint.
  */
-@ClientEndpoint
-public class PolygonWebsocketClientEndpoint extends AbstractWebsocketClientEndpoint<String> {
+@ClientEndpoint(subprotocols = "TEXT")
+public class PolygonWebsocketClientEndpoint extends AbstractWebsocketClientEndpoint {
 
     /**
      * Instantiates a new Polygon websocket client endpoint.
@@ -28,19 +28,16 @@ public class PolygonWebsocketClientEndpoint extends AbstractWebsocketClientEndpo
     }
 
     @OnOpen
-    @Override
     public void onOpenAnnotated(Session userSession) {
         super.onOpen(userSession);
     }
 
     @OnClose
-    @Override
     public void onCloseAnnotated(Session userSession, CloseReason reason) {
         super.onClose(userSession, reason);
     }
 
     @OnMessage
-    @Override
     public void onMessageAnnotated(String message) {
         super.onMessage(message);
     }

--- a/src/main/java/io/github/mainstringargs/util/gson/GsonUtil.java
+++ b/src/main/java/io/github/mainstringargs/util/gson/GsonUtil.java
@@ -12,7 +12,6 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
@@ -51,8 +50,8 @@ public class GsonUtil {
         List<String> classKeys = new ArrayList<>();
         gsonSerializedNameAnnotations.forEach((c) -> classKeys.add(c.value()));
 
-        for (String key : jsonObjectKeys){
-            if (!classKeys.contains(key)){
+        for (String key : jsonObjectKeys) {
+            if (!classKeys.contains(key)) {
                 return false;
             }
         }


### PR DESCRIPTION
Fixes https://github.com/mainstringargs/alpaca-java/issues/57 and https://github.com/mainstringargs/alpaca-java/pull/58.
We haven't been using the Tyrus client for some time now so that library was irrelevant. The issue was cause by some protocol update on Polygon's end that the javax.websocket library hasn't been updated for. So this PR switches to the updated Jetty websocket implementation with the javax.websocket interface.