### PR TITLE
Change Trade ID field from int to string

### DIFF
--- a/schema_json/polygon/websocket/trade/trade_message.json
+++ b/schema_json/polygon/websocket/trade/trade_message.json
@@ -10,7 +10,7 @@
       "title": "Exchange ID"
     },
     "i": {
-      "existingJavaType": "java.lang.Integer",
+      "existingJavaType": "java.lang.String",
       "title": "Trade ID"
     },
     "z": {


### PR DESCRIPTION
@mainstringargs don’t merge this quite yet as I’m still seeing some messages with the Trade ID value being a number rather than a string... Polygon isn’t consistent with the message structure right now. I’m going to ask them. 